### PR TITLE
feat(tests): add PHPUnit and test helper to the application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ runtime
 rr*
 spiral*
 .env
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,9 @@
     "cycle/annotated": "^2.0",
     "cycle/migrations": "^1.0"
   },
+  "require-dev": {
+    "phpunit/phpunit": "^8.5"
+  },
   "scripts": {
     "post-create-project-cmd": [
       "php -r \"copy('.env.sample', '.env');\"",
@@ -49,6 +52,11 @@
   "autoload": {
     "psr-4": {
       "App\\": "app/src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Tests\\": "tests/"
     }
   },
   "extra": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="false"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         stopOnError="false"
+         stderr="true">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Feature">
+            <directory suffix="Test.php">tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">app/src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Feature/BasicTest.php
+++ b/tests/Feature/BasicTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class BasicTest extends TestCase
+{
+    public function testDefaultActionWorks(): void
+    {
+        $want = 'Welcome to Spiral Framework<';
+        $got = (string)$this->get('/')->getBody();
+
+        $this->assertStringContainsString($want, $got);
+    }
+
+    public function testDefaultActionWithRuLocale(): void
+    {
+        $want = 'Вас приветствует Spiral Framework';
+        $got = (string)$this->get('/', [], [ 'accept-language' => 'ru'])->getBody();
+
+        $this->assertStringContainsString($want, $got);
+    }
+}

--- a/tests/Feature/BasicTest.php
+++ b/tests/Feature/BasicTest.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Kairee Wu (krwu)
+ */
+
 declare(strict_types=1);
 
 namespace Tests\Feature;

--- a/tests/TestApp.php
+++ b/tests/TestApp.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Kairee Wu (krwu)
+ */
+
 declare(strict_types=1);
 
 namespace Tests;

--- a/tests/TestApp.php
+++ b/tests/TestApp.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests;
+
+use App\App;
+
+class TestApp extends App
+{
+    public function get($alias, string $context = null)
+    {
+        return $this->container->get($alias, $context);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase as BaseTestCase;
+use Spiral\Boot\DirectoriesInterface;
+use Spiral\Boot\Environment;
+use Spiral\Files\Files;
+use Spiral\Http\Http;
+use Spiral\Translator\TranslatorInterface;
+use Spiral\Views\ViewsInterface;
+use Tests\Traits\InteractsWithConsole;
+use Tests\Traits\InteractsWithHttp;
+
+abstract class TestCase extends BaseTestCase
+{
+    use InteractsWithConsole,
+        InteractsWithHttp;
+
+    /** @var \Spiral\Boot\AbstractKernel */
+    protected $app;
+    /** @var \Spiral\Http\Http */
+    protected $http;
+    /** @var \Spiral\Views\ViewsInterface */
+    protected $views;
+
+    protected function makeApp(array $env = []): TestApp
+    {
+        return TestApp::init([
+            'root' => __DIR__ . '/../',
+            'app' => __DIR__ . '/../app',
+            'runtime' => __DIR__ . '/../runtime/tests',
+            'cache' => __DIR__ . '/../runtime/tests'
+        ], new Environment($env), false);
+    }
+
+    protected function setUp(): void
+    {
+        $this->app = $this->makeApp();
+        $this->http = $this->app->get(HTTP::class);
+        $this->views = $this->app->get(ViewsInterface::class);
+        $this->app->get(TranslatorInterface::class)->setLocale('en');
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $fs = new Files();
+
+        if ($fs->isDirectory(__DIR__ . '/../app/migrations')) {
+            $fs->deleteDirectory(__DIR__ . '/../app/migrations');
+        }
+
+        $runtime = $this->app->get(DirectoriesInterface::class)->get('runtime');
+        if ($fs->isDirectory($runtime)) {
+            $fs->deleteDirectory($runtime);
+        }
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Kairee Wu (krwu)
+ */
+
 declare(strict_types=1);
 
 namespace Tests;
@@ -16,8 +23,8 @@ use Tests\Traits\InteractsWithHttp;
 
 abstract class TestCase extends BaseTestCase
 {
-    use InteractsWithConsole,
-        InteractsWithHttp;
+    use InteractsWithConsole;
+    use InteractsWithHttp;
 
     /** @var \Spiral\Boot\AbstractKernel */
     protected $app;

--- a/tests/Traits/InteractsWithConsole.php
+++ b/tests/Traits/InteractsWithConsole.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Traits;
+
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+trait InteractsWithConsole
+{
+    public function runCommand(string $command, array $args = []): string
+    {
+        $input = new ArrayInput($args);
+        $output = new BufferedOutput();
+
+        $this->app->console()->run($command, $input, $output);
+
+        return $output->fetch();
+    }
+
+    public function runCommandDebug(string $command, array $args = [], OutputInterface $output = null): string
+    {
+        $input = new ArrayInput($args);
+        $output = $output ?? new BufferedOutput();
+        $output->setVerbosity(BufferedOutput::VERBOSITY_VERBOSE);
+
+        $this->app->console()->run($command, $input, $output);
+
+        return $output->fetch();
+    }
+
+    public function runCommandVeryVerbose(string $command, array $args = [], OutputInterface $output = null): string
+    {
+        $input = new ArrayInput($args);
+        $output = $output ?? new BufferedOutput();
+        $output->setVerbosity(BufferedOutput::VERBOSITY_DEBUG);
+
+        $this->app->console()->run($command, $input, $output);
+
+        return $output->fetch();
+    }
+}

--- a/tests/Traits/InteractsWithConsole.php
+++ b/tests/Traits/InteractsWithConsole.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Kairee Wu (krwu)
+ */
+
 declare(strict_types=1);
 
 namespace Tests\Traits;

--- a/tests/Traits/InteractsWithHttp.php
+++ b/tests/Traits/InteractsWithHttp.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Kairee Wu (krwu)
+ */
 
 namespace Tests\Traits;
 

--- a/tests/Traits/InteractsWithHttp.php
+++ b/tests/Traits/InteractsWithHttp.php
@@ -1,0 +1,78 @@
+<?php
+
+
+namespace Tests\Traits;
+
+use Psr\Http\Message\ResponseInterface;
+use Zend\Diactoros\ServerRequest;
+
+trait InteractsWithHttp
+{
+    public function get(
+        $uri,
+        array $query = [],
+        array $headers = [],
+        array $cookies = []
+    ): ResponseInterface {
+        return $this->http->handle($this->request($uri, 'GET', $query, $headers, $cookies));
+    }
+
+    public function getWithAttributes(
+        $uri,
+        array $attributes,
+        array $headers = []
+    ): ResponseInterface {
+        $r = $this->request($uri, 'GET', [], $headers, []);
+        foreach ($attributes as $k => $v) {
+            $r = $r->withAttribute($k, $v);
+        }
+
+        return $this->http->handle($r);
+    }
+
+
+    public function post(
+        $uri,
+        array $data = [],
+        array $headers = [],
+        array $cookies = []
+    ): ResponseInterface {
+        return $this->http->handle(
+            $this->request($uri, 'POST', [], $headers, $cookies)->withParsedBody($data)
+        );
+    }
+
+    public function request(
+        $uri,
+        string $method,
+        array $query = [],
+        array $headers = [],
+        array $cookies = []
+    ): ServerRequest {
+        $headers = array_merge([
+            'accept-language' => 'en'
+        ], $headers);
+
+        return new ServerRequest(
+            [],
+            [],
+            $uri,
+            $method,
+            'php://input',
+            $headers,
+            $cookies,
+            $query
+        );
+    }
+
+    public function fetchCookies(array $header)
+    {
+        $result = [];
+        foreach ($header as $line) {
+            $cookie = explode('=', $line);
+            $result[$cookie[0]] = rawurldecode(substr($cookie[1], 0, strpos($cookie[1], ';')));
+        }
+
+        return $result;
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+error_reporting(E_ALL | E_STRICT);
+ini_set('display_errors', '1');
+
+//Composer
+require dirname(__DIR__) . '/vendor/autoload.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Kairee Wu (krwu)
+ */
+
 declare(strict_types=1);
 
 error_reporting(E_ALL | E_STRICT);


### PR DESCRIPTION
To users who use this skeleton application,  they should be able to start writing tests immediately.

I add PHPUnit and the startup configuration for the spiral app.

## Usage:

1. Every test class should extend `Tests\TestCase`, not `PHPUnit\Framework\TestCase`
2. There are some helpful methods to interact with Console and Web Server ( codes was copied from [tests of Spiral Framework](https://github.com/spiral/framework/tree/master/tests/). like `$this->get()`, `$this->post`, `$this->request`, `$this->runCommand`, etc.