### PR TITLE
fix: replace deprecated addRoute with setRoute

### DIFF
--- a/app/src/Bootloader/RoutesBootloader.php
+++ b/app/src/Bootloader/RoutesBootloader.php
@@ -27,7 +27,7 @@ class RoutesBootloader extends Bootloader
     public function boot(RouterInterface $router): void
     {
         // named route
-        $router->addRoute(
+        $router->setRoute(
             'html',
             new Route('/<action>.html', new Controller(HomeController::class))
         );


### PR DESCRIPTION
The method `addRoute` has deprecated, it should be replaced with new `setRoute`