### PR TITLE
fixed grammar in .env.sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,7 @@
-# Debug mode disabled view cache and enabled higher verbosity.
+# Debug mode set to TRUE disables view caching and enables higher verbosity.
 DEBUG = true
 
-# Set to application specific value, used to encrypt/decrypt cookies and etc.
+# Set to an application specific value, used to encrypt/decrypt cookies etc.
 ENCRYPTER_KEY = {encrypt-key}
 
 # Set to TRUE to disable confirmation in `migrate` commands.


### PR DESCRIPTION
Corrected grammar related to the description of the functionality of the DEBUG environment variable.
Small grammar fix for line describing the ENCRYPTER_KEY.

related: [pull request 136 in the docs](https://github.com/spiral/docs/pull/136)