### PR TITLE
Remove spaces around equal (=) signs (.env.sample)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,8 +1,8 @@
 # Debug mode set to TRUE disables view caching and enables higher verbosity.
-DEBUG = true
+DEBUG=true
 
 # Set to an application specific value, used to encrypt/decrypt cookies etc.
-ENCRYPTER_KEY = {encrypt-key}
+ENCRYPTER_KEY={encrypt-key}
 
 # Set to TRUE to disable confirmation in `migrate` commands.
-SAFE_MIGRATIONS = true
+SAFE_MIGRATIONS=true


### PR DESCRIPTION
**What**
Removed the spaces around the equal signs in the .env.sample file. 

**Why**
Docker does not allow whitespaces in environment variable values. When you try to boot docker (compose) using the .env copied from the sample file (as it currently is) it results into the following error:

```
ERROR: In file ./.env: environment variable name 'DEBUG ' may not contain whitespace.
```