### PR TITLE
add missed method for InteractsWithConsole

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "cycle/migrations": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.5"
+    "phpunit/phpunit": "^9.0"
   },
   "scripts": {
     "post-create-project-cmd": [

--- a/tests/Feature/BasicTest.php
+++ b/tests/Feature/BasicTest.php
@@ -30,4 +30,11 @@ class BasicTest extends TestCase
 
         $this->assertStringContainsString($want, $got);
     }
+
+    public function testInteractWithConsole(): void
+    {
+        $output = $this->runCommand('views:reset');
+
+        $this->assertStringContainsString('cache', $output);
+    }
 }

--- a/tests/Traits/InteractsWithConsole.php
+++ b/tests/Traits/InteractsWithConsole.php
@@ -14,15 +14,25 @@ namespace Tests\Traits;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Spiral\Console\Console;
 
 trait InteractsWithConsole
 {
+
+    /**
+     * @return \Spiral\Console\Console
+     */
+    public function console(): Console
+    {
+        return $this->app->get(Console::class);
+    }
+
     public function runCommand(string $command, array $args = []): string
     {
         $input = new ArrayInput($args);
         $output = new BufferedOutput();
 
-        $this->app->console()->run($command, $input, $output);
+        $this->console()->run($command, $input, $output);
 
         return $output->fetch();
     }
@@ -33,7 +43,7 @@ trait InteractsWithConsole
         $output = $output ?? new BufferedOutput();
         $output->setVerbosity(BufferedOutput::VERBOSITY_VERBOSE);
 
-        $this->app->console()->run($command, $input, $output);
+        $this->console()->run($command, $input, $output);
 
         return $output->fetch();
     }
@@ -44,7 +54,7 @@ trait InteractsWithConsole
         $output = $output ?? new BufferedOutput();
         $output->setVerbosity(BufferedOutput::VERBOSITY_DEBUG);
 
-        $this->app->console()->run($command, $input, $output);
+        $this->console()->run($command, $input, $output);
 
         return $output->fetch();
     }


### PR DESCRIPTION
There should be a method `console()` which returns an instance of `Spiral\Console\Console`.

After merge this PR, `$this->runCommand` can be used at any test method. Like:

```php
    public function testInteractWithConsole(): void
    {
        $output = $this->runCommand('views:reset');

        $this->assertStringContainsString('cache', $output);
    }
```

This PR can Close #27 