### PR TITLE
Exit with 255 on App::init() failure

### DIFF
--- a/app.php
+++ b/app.php
@@ -32,7 +32,9 @@ require __DIR__ . '/vendor/autoload.php';
 //
 $app = App::init(['root' => __DIR__]);
 
-if ($app !== null) {
-    $code = (int)$app->serve();
-    exit($code);
+if ($app === null) {
+    exit(255);
 }
+
+$code = (int)$app->serve();
+exit($code);


### PR DESCRIPTION
`php app.php` should return 255 if application is not able to init. It's important for CI/CD purposes where checking exit code is the most convenient way to know if command executed properly