### PR TITLE
Adds support for CycleORM v2.0-x-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Spiral Framework is a High-Performance PHP/Go Full-Stack framework and group of 
 Server Requirements
 --------
 Make sure that your server is configured with following PHP version and extensions:
-* PHP 7.2+, 64bit
+* PHP 8.0+, 64bit
 * *mb-string* extension
 * PDO Extension with desired database drivers
 

--- a/app/config/cycle.php
+++ b/app/config/cycle.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Cycle\ORM\SchemaInterface;
+
+return [
+    'schema' => [
+        'defaults' => [
+            SchemaInterface::MAPPER => \Cycle\ORM\Mapper\Mapper::class,
+            // SchemaInterface::MAPPER => \Cycle\ORM\Mapper\PromiseMapper::class,
+
+            // SchemaInterface::REPOSITORY => \App\Repository::class,
+            // SchemaInterface::TYPECAST_HANDLER => [
+            //    \Cycle\ORM\Parser\Typecast::class
+            //],
+        ]
+    ],
+];

--- a/app/config/database.php
+++ b/app/config/database.php
@@ -1,22 +1,17 @@
 <?php
 
-/**
- * This file is part of Spiral package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 declare(strict_types=1);
+
+use Cycle\Database;
 
 return [
     /**
      * Default database connection
      */
-    'default'   => 'default',
+    'default' => env('DB_DEFAULT', 'default'),
 
     /**
-     * The Spiral/Database module provides support to manage multiple databases
+     * The Cycle/Database module provides support to manage multiple databases
      * in one application, use read/write connections and logically separate
      * multiple databases within one connection using prefixes.
      *
@@ -35,11 +30,33 @@ return [
      * database drivers. To register a new connection you have to specify
      * the driver class and its connection options.
      */
-    'drivers'   => [
-        'sqlite' => [
-            'driver'     => \Spiral\Database\Driver\SQLite\SQLiteDriver::class,
-            'connection' => 'sqlite:' . directory('root') . 'app.db',
-            'profiling'  => true,
-        ],
+    'drivers' => [
+        'sqlite' => new Database\Config\SQLiteDriverConfig(
+            connection: new Database\Config\SQLite\FileConnectionConfig(
+                database: env('DB_DATABASE', __DIR__.'./../../runtime/database.sqlite')
+            ),
+            queryCache: true,
+        ),
+        'mysql' => new Database\Config\MySQLDriverConfig(
+            connection: new Database\Config\MySQL\TcpConnectionConfig(
+                database: env('DB_DATABASE', 'forge'),
+                host: env('DB_HOST', '127.0.0.1'),
+                port: (int)env('DB_PORT', 3306),
+                user: env('DB_USERNAME', 'forge'),
+                password: env('DB_PASSWORD', ''),
+            ),
+            queryCache: true
+        ),
+        'postgres' => new Database\Config\PostgresDriverConfig(
+            connection: new Database\Config\Postgres\TcpConnectionConfig(
+                database: env('DB_DATABASE', 'forge'),
+                host: env('DB_HOST', '127.0.0.1'),
+                port: (int)env('DB_PORT', 5432),
+                user: env('DB_USERNAME', 'forge'),
+                password: env('DB_PASSWORD', ''),
+            ),
+            schema: 'public',
+            queryCache: true,
+        ),
     ],
 ];

--- a/app/config/migrations.php
+++ b/app/config/migrations.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    // directory to store migration files
+    'directory' => directory('application').'migrations/',
+
+    // Table name to store information about migrations status (per database)
+    'table' => 'migrations',
+
+    // When set to true no confirmation will be requested on migration run.
+    'safe' => env('SPIRAL_ENV') == 'develop',
+];

--- a/app/locale/ru/messages.en.php
+++ b/app/locale/ru/messages.en.php
@@ -3,13 +3,13 @@
 declare(strict_types=1);
 
 return [
-    'GitHub'                       => 'GitHub',
-    'Exception'                    => 'Страница ошибки',
-    'Create Queue Task'            => 'Создать фоновую задачу',
-    'Application Metrics'          => 'Prometheus метрики',
-    'Website and Documentation'    => 'Документация',
-    'Welcome To Spiral'            => 'Добро пожаловать',
-    'Welcome to Spiral Framework'  => 'Вас приветствует Spiral Framework',
+    'GitHub' => 'GitHub',
+    'Exception' => 'Страница ошибки',
+    'Create Queue Task' => 'Создать фоновую задачу',
+    'Application Metrics' => 'Prometheus метрики',
+    'Website and Documentation' => 'Документация',
+    'Welcome To Spiral' => 'Добро пожаловать',
+    'Welcome to Spiral Framework' => 'Вас приветствует Spiral Framework',
     'This view file is located in' => 'Данный шаблон находится в файле',
-    'and rendered by'              => 'и вызван контроллером',
+    'and rendered by' => 'и вызван контроллером',
 ];

--- a/app/src/App.php
+++ b/app/src/App.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of Spiral package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 declare(strict_types=1);
 
 namespace App;
@@ -56,13 +49,13 @@ class App extends Kernel
         Framework\Http\PaginationBootloader::class,
 
         // Databases
-        Framework\Database\DatabaseBootloader::class,
-        Framework\Database\MigrationsBootloader::class,
+        Bootloader\DatabaseBootloader::class,
+        Bootloader\MigrationsBootloader::class,
 
         // ORM
-        Framework\Cycle\CycleBootloader::class,
-        Framework\Cycle\ProxiesBootloader::class,
-        Framework\Cycle\AnnotatedBootloader::class,
+        Bootloader\CycleOrmV2Bootloader::class,
+        Bootloader\SchemaBootloader::class,
+        Bootloader\AnnotatedBootloader::class,
 
         // Views and view translation
         Framework\Views\ViewsBootloader::class,
@@ -75,8 +68,11 @@ class App extends Kernel
         Stempler\StemplerBootloader::class,
 
         // Framework commands
-        Framework\CommandBootloader::class,
+        Bootloader\CommandBootloader::class,
         Scaffolder\ScaffolderBootloader::class,
+
+        // Sentry exceptions logger
+        // \Spiral\Sentry\Bootloader\SentryBootloader::class,
 
         // Debug and debug extensions
         Framework\DebugBootloader::class,

--- a/app/src/Bootloader/AnnotatedBootloader.php
+++ b/app/src/Bootloader/AnnotatedBootloader.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Bootloader;
+
+use Cycle\Annotated;
+use Spiral\Attributes\Factory;
+use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Bootloader\TokenizerBootloader;
+use Spiral\Tokenizer\ClassesInterface;
+
+final class AnnotatedBootloader extends Bootloader
+{
+    protected const DEPENDENCIES = [
+        SchemaBootloader::class,
+        TokenizerBootloader::class,
+    ];
+
+    protected const BINDINGS = [
+        Annotated\Embeddings::class => [self::class, 'initEmbeddings'],
+        Annotated\Entities::class => [self::class, 'initEntities'],
+        Annotated\MergeColumns::class => [self::class, 'initMergeColumns'],
+        Annotated\TableInheritance::class => [self::class, 'initTableInheritance'],
+        Annotated\MergeIndexes::class => [self::class, 'initMergeIndexes'],
+    ];
+
+    public function boot(SchemaBootloader $schema): void
+    {
+        // AnnotationRegistry::registerLoader('class_exists');
+
+        $schema->addGenerator(SchemaBootloader::GROUP_INDEX, Annotated\Embeddings::class);
+        $schema->addGenerator(SchemaBootloader::GROUP_INDEX, Annotated\Entities::class);
+        $schema->addGenerator(SchemaBootloader::GROUP_INDEX, Annotated\MergeColumns::class);
+        $schema->addGenerator(SchemaBootloader::GROUP_RENDER, Annotated\TableInheritance::class);
+        $schema->addGenerator(SchemaBootloader::GROUP_RENDER, Annotated\MergeIndexes::class);
+    }
+
+    private function initEmbeddings(ClassesInterface $classes): Annotated\Embeddings
+    {
+        return new Annotated\Embeddings(
+            $classes, (new Factory)->create()
+        );
+    }
+
+    public function initEntities(ClassesInterface $classes): Annotated\Entities
+    {
+        return new Annotated\Entities(
+            $classes, (new Factory)->create()
+        );
+    }
+
+    public function initMergeColumns(ClassesInterface $classes): Annotated\MergeColumns
+    {
+        return new Annotated\MergeColumns((new Factory)->create());
+    }
+
+    public function initTableInheritance(ClassesInterface $classes): Annotated\TableInheritance
+    {
+        return new Annotated\TableInheritance((new Factory)->create());
+    }
+
+    public function initMergeIndexes(ClassesInterface $classes): Annotated\MergeIndexes
+    {
+        return new Annotated\MergeIndexes((new Factory)->create());
+    }
+}
+

--- a/app/src/Bootloader/CommandBootloader.php
+++ b/app/src/Bootloader/CommandBootloader.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Bootloader;
+
+use App\Console\Command\Database;
+use App\Console\Command\CycleOrm;
+use App\Console\Command\Migrate;
+use Cycle\Database\DatabaseProviderInterface;
+use Cycle\ORM\ORMInterface;
+use Psr\Container\ContainerInterface;
+use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Bootloader\ConsoleBootloader;
+use Spiral\Command\Router;
+use Spiral\Command\Translator;
+use Spiral\Command\Views;
+use Spiral\Command\GRPC;
+use Spiral\Command\Encrypter;
+use Spiral\Console\Sequence\RuntimeDirectory;
+use Spiral\Core\Container;
+use Spiral\Console;
+use Spiral\Encrypter\EncryptionInterface;
+use Spiral\Files\FilesInterface;
+use Cycle\Migrations\Migrator;
+use Spiral\Router\RouterInterface;
+use Spiral\Translator\Config\TranslatorConfig;
+use Spiral\Translator\TranslatorInterface;
+use Spiral\Views\ViewsInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class CommandBootloader extends Bootloader
+{
+    protected const DEPENDENCIES = [
+        ConsoleBootloader::class,
+        MigrationsBootloader::class,
+    ];
+
+    public function boot(ConsoleBootloader $console, Container $container): void
+    {
+        $console->addCommand(Console\Command\ConfigureCommand::class);
+        $console->addCommand(Console\Command\UpdateCommand::class);
+
+        $console->addConfigureSequence(
+            [RuntimeDirectory::class, 'ensure'],
+            '<fg=magenta>[runtime]</fg=magenta> <fg=cyan>verify `runtime` directory access</fg=cyan>'
+        );
+
+        $this->configureExtensions($console, $container);
+    }
+
+    private function configureExtensions(ConsoleBootloader $console, Container $container): void
+    {
+        if ($container->has(DatabaseProviderInterface::class)) {
+            $this->configureDatabase($console);
+        }
+
+        if ($container->has(ORMInterface::class)) {
+            $this->configureCycle($console, $container);
+        }
+
+        if ($container->has(TranslatorInterface::class)) {
+            $this->configureTranslator($console);
+        }
+
+        if ($container->has(ViewsInterface::class)) {
+            $this->configureViews($console);
+        }
+
+        if ($container->has(Migrator::class)) {
+            $this->configureMigrations($console);
+        }
+
+        if ($container->has(InvokerInterface::class)) {
+            $this->configureGRPC($console);
+        }
+
+        if ($container->has(EncryptionInterface::class)) {
+            $this->configureEncrypter($console);
+        }
+
+        if ($container->has(RouterInterface::class)) {
+            $console->addCommand(Router\ListCommand::class);
+        }
+    }
+
+    private function configureDatabase(ConsoleBootloader $console): void
+    {
+        $console->addCommand(Database\ListCommand::class);
+        $console->addCommand(Database\TableCommand::class);
+    }
+
+    private function configureCycle(ConsoleBootloader $console, ContainerInterface $container): void
+    {
+        $console->addCommand(CycleOrm\UpdateCommand::class);
+        $console->addCommand(CycleOrm\RenderCommand::class);
+
+        $console->addUpdateSequence(
+            'cycle',
+            '<fg=magenta>[cycle]</fg=magenta> <fg=cyan>update Cycle schema...</fg=cyan>'
+        );
+
+        $console->addCommand(CycleOrm\SyncCommand::class);
+
+        if ($container->has(Migrator::class)) {
+            $console->addCommand(CycleOrm\MigrateCommand::class);
+        }
+    }
+
+    private function configureTranslator(ConsoleBootloader $console): void
+    {
+        $console->addCommand(Translator\IndexCommand::class);
+        $console->addCommand(Translator\ExportCommand::class);
+        $console->addCommand(Translator\ResetCommand::class);
+
+        $console->addConfigureSequence(
+            function (FilesInterface $files, TranslatorConfig $config, OutputInterface $output): void {
+                $files->ensureDirectory($config->getLocaleDirectory($config->getDefaultLocale()));
+                $output->writeln('<info>The default locale directory has been ensured.</info>');
+            },
+            '<fg=magenta>[i18n]</fg=magenta> <fg=cyan>ensure default locale directory...</fg=cyan>'
+        );
+
+        $console->addConfigureSequence(
+            'i18n:index',
+            '<fg=magenta>[i18n]</fg=magenta> <fg=cyan>scan translator function and [[values]] usage...</fg=cyan>'
+        );
+    }
+
+    private function configureViews(ConsoleBootloader $console): void
+    {
+        $console->addCommand(Views\ResetCommand::class);
+        $console->addCommand(Views\CompileCommand::class);
+
+        $console->addConfigureSequence(
+            'views:compile',
+            '<fg=magenta>[views]</fg=magenta> <fg=cyan>warm up view cache...</fg=cyan>'
+        );
+    }
+
+    private function configureMigrations(ConsoleBootloader $console): void
+    {
+        $console->addCommand(Migrate\InitCommand::class);
+        $console->addCommand(Migrate\StatusCommand::class);
+        $console->addCommand(Migrate\MigrateCommand::class);
+        $console->addCommand(Migrate\RollbackCommand::class);
+        $console->addCommand(Migrate\ReplayCommand::class);
+    }
+
+    private function configureGRPC(ConsoleBootloader $console): void
+    {
+        $console->addCommand(GRPC\GenerateCommand::class);
+        $console->addCommand(GRPC\ListCommand::class);
+    }
+
+    private function configureEncrypter(ConsoleBootloader $console): void
+    {
+        $console->addCommand(Encrypter\KeyCommand::class);
+    }
+
+}

--- a/app/src/Bootloader/CycleOrmV2Bootloader.php
+++ b/app/src/Bootloader/CycleOrmV2Bootloader.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Bootloader;
+
+use Cycle\Database\DatabaseProviderInterface;
+use Cycle\ORM\Collection\ArrayCollectionFactory;
+use Cycle\ORM\Collection\CollectionFactoryInterface;
+use Cycle\ORM\Collection\DoctrineCollectionFactory;
+use Cycle\ORM\Collection\IlluminateCollectionFactory;
+use Cycle\ORM\Config\RelationConfig;
+use Cycle\ORM\Factory;
+use Cycle\ORM\FactoryInterface;
+use Cycle\ORM\ORM;
+use Cycle\ORM\ORMInterface;
+use Cycle\ORM\RepositoryInterface;
+use Cycle\ORM\SchemaInterface;
+use Cycle\ORM\Transaction;
+use Cycle\ORM\TransactionInterface;
+use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Boot\FinalizerInterface;
+use Spiral\Core\Container;
+use Spiral\Cycle\RepositoryInjector;
+
+final class CycleOrmV2Bootloader extends Bootloader
+{
+    protected const DEPENDENCIES = [
+        DatabaseBootloader::class,
+        SchemaBootloader::class,
+    ];
+
+    protected const BINDINGS = [
+        TransactionInterface::class => Transaction::class,
+
+        // You can choose preferable collections for relations
+        CollectionFactoryInterface::class => ArrayCollectionFactory::class,
+        // CollectionFactoryInterface::class => DoctrineCollectionFactory::class,
+        // CollectionFactoryInterface::class => IlluminateCollectionFactory::class,
+    ];
+
+    protected const SINGLETONS = [
+        ORMInterface::class => ORM::class,
+        ORM::class => [self::class, 'orm'],
+        FactoryInterface::class => [self::class, 'factory'],
+    ];
+
+    public function boot(Container $container, FinalizerInterface $finalizer): void
+    {
+        $finalizer->addFinalizer(
+            function () use ($container): void {
+                if ($container->hasInstance(ORMInterface::class)) {
+                    $container->get(ORMInterface::class)->getHeap()->clean();
+                }
+            }
+        );
+
+        $container->bindInjector(RepositoryInterface::class, RepositoryInjector::class);
+    }
+
+    private function orm(
+        FactoryInterface $factory,
+        SchemaInterface $schema = null
+    ): ORMInterface {
+        return new ORM($factory, $schema);
+    }
+
+    private function factory(
+        DatabaseProviderInterface $dbal,
+        Container $container,
+        CollectionFactoryInterface $collectionFactory
+    ): FactoryInterface {
+        return new Factory($dbal, RelationConfig::getDefault(), $container, $collectionFactory);
+    }
+}

--- a/app/src/Bootloader/DatabaseBootloader.php
+++ b/app/src/Bootloader/DatabaseBootloader.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Bootloader;
+
+use Cycle\Database\Database;
+use Cycle\Database\DatabaseInterface;
+use Cycle\Database\DatabaseManager;
+use Cycle\Database\DatabaseProviderInterface;
+use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Config\ConfiguratorInterface;
+use Spiral\Core\Container\SingletonInterface;
+
+final class DatabaseBootloader extends Bootloader implements SingletonInterface
+{
+    protected const SINGLETONS = [
+        DatabaseProviderInterface::class => DatabaseManager::class,
+    ];
+
+    protected const BINDINGS = [
+        DatabaseInterface::class => Database::class,
+    ];
+
+    private ConfiguratorInterface $config;
+
+    public function __construct(ConfiguratorInterface $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * Init database config.
+     */
+    public function boot(): void
+    {
+        $this->config->setDefaults(
+            'database',
+            [
+                'default' => 'default',
+                'aliases' => [],
+                'databases' => [],
+                'drivers' => [],
+            ]
+        );
+    }
+}
+

--- a/app/src/Bootloader/DatabaseBootloader.php
+++ b/app/src/Bootloader/DatabaseBootloader.php
@@ -22,11 +22,9 @@ final class DatabaseBootloader extends Bootloader implements SingletonInterface
         DatabaseInterface::class => Database::class,
     ];
 
-    private ConfiguratorInterface $config;
-
-    public function __construct(ConfiguratorInterface $config)
-    {
-        $this->config = $config;
+    public function __construct(
+        private ConfiguratorInterface $config
+    ) {
     }
 
     /**

--- a/app/src/Bootloader/LocaleSelectorBootloader.php
+++ b/app/src/Bootloader/LocaleSelectorBootloader.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of Spiral package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 declare(strict_types=1);
 
 namespace App\Bootloader;

--- a/app/src/Bootloader/LoggingBootloader.php
+++ b/app/src/Bootloader/LoggingBootloader.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of Spiral package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 declare(strict_types=1);
 
 namespace App\Bootloader;

--- a/app/src/Bootloader/MigrationsBootloader.php
+++ b/app/src/Bootloader/MigrationsBootloader.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Bootloader;
+
+use Cycle\Migrations\Config\MigrationConfig;
+use Cycle\Migrations\FileRepository;
+use Cycle\Migrations\Migrator;
+use Cycle\Migrations\RepositoryInterface;
+use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Boot\DirectoriesInterface;
+use Spiral\Boot\EnvironmentInterface;
+use Spiral\Bootloader\TokenizerBootloader;
+use Spiral\Config\ConfiguratorInterface;
+
+final class MigrationsBootloader extends Bootloader
+{
+    protected const DEPENDENCIES = [
+        TokenizerBootloader::class,
+        DatabaseBootloader::class,
+    ];
+
+    protected const SINGLETONS = [
+        Migrator::class => Migrator::class,
+        RepositoryInterface::class => FileRepository::class,
+    ];
+
+    public function boot(
+        ConfiguratorInterface $config,
+        EnvironmentInterface $env,
+        DirectoriesInterface $dirs
+    ): void {
+        if (!$dirs->has('migrations')) {
+            $dirs->set('migrations', $dirs->get('app').'migrations');
+        }
+
+        $config->setDefaults(
+            'migration',
+            [
+                'directory' => $dirs->get('migrations'),
+                'table' => 'migrations',
+                'safe' => $env->get('SAFE_MIGRATIONS', false),
+            ]
+        );
+    }
+}

--- a/app/src/Bootloader/RoutesBootloader.php
+++ b/app/src/Bootloader/RoutesBootloader.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of Spiral package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 declare(strict_types=1);
 
 namespace App\Bootloader;

--- a/app/src/Bootloader/SchemaBootloader.php
+++ b/app/src/Bootloader/SchemaBootloader.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Bootloader;
+
+use Cycle\ORM\SchemaInterface;
+use Cycle\Schema\GeneratorInterface;
+use Cycle\Schema\Registry;
+use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Boot\MemoryInterface;
+use Spiral\Bootloader\TokenizerBootloader;
+use Spiral\Core\Container;
+use Spiral\Cycle\SchemaCompiler;
+use Cycle\Schema\Generator;
+
+final class SchemaBootloader extends Bootloader implements Container\SingletonInterface
+{
+    public const GROUP_INDEX = 'index';
+    public const GROUP_RENDER = 'render';
+    public const GROUP_POSTPROCESS = 'postprocess';
+
+    protected const DEPENDENCIES = [
+        TokenizerBootloader::class,
+    ];
+
+    protected const BINDINGS = [
+        SchemaInterface::class => [self::class, 'schema'],
+    ];
+
+    private Container $container;
+
+    /** @var string[][]|GeneratorInterface[][] */
+    private array $generators = [];
+
+    public function __construct(Container $container)
+    {
+        $this->container = $container;
+        $this->generators = [
+            self::GROUP_INDEX => [
+                // find available entities
+            ],
+            self::GROUP_RENDER => [
+                // render tables and relations
+                Generator\ResetTables::class,
+                Generator\GenerateRelations::class,
+                Generator\ValidateEntities::class,
+                Generator\RenderTables::class,
+                Generator\RenderRelations::class,
+            ],
+            self::GROUP_POSTPROCESS => [
+                // post processing
+                Generator\GenerateTypecast::class,
+            ],
+        ];
+    }
+
+    public function addGenerator(string $group, string $generator): void
+    {
+        $this->generators[$group][] = $generator;
+    }
+
+    /**
+     * @return GeneratorInterface[]
+     * @throws \Throwable
+     */
+    public function getGenerators(): array
+    {
+        $result = [];
+        foreach ($this->generators as $group) {
+            foreach ($group as $generator) {
+                if (is_object($generator) && !$generator instanceof Container\Autowire) {
+                    $result[] = $generator;
+                } else {
+                    $result[] = $this->container->get($generator);
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    protected function schema(MemoryInterface $memory): SchemaInterface
+    {
+        $schemaCompiler = SchemaCompiler::fromMemory($memory);
+        if ($schemaCompiler->isEmpty()) {
+            $schemaCompiler = SchemaCompiler::compile(
+                $this->container->get(Registry::class),
+                $this->getGenerators()
+            );
+
+            $schemaCompiler->toMemory($memory);
+        }
+
+        return $schemaCompiler->toSchema();
+    }
+}
+

--- a/app/src/Bootloader/SchemaCompiler.php
+++ b/app/src/Bootloader/SchemaCompiler.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Bootloader;
+
+use Cycle\ORM\Schema;
+use Cycle\ORM\SchemaInterface;
+use Cycle\Schema\Compiler;
+use Cycle\Schema\Registry;
+use Spiral\Boot\MemoryInterface;
+
+final class SchemaCompiler
+{
+    private const MEMORY_SECTION = 'cycle';
+    private const EMPTY_SCHEMA   = ':empty:';
+
+    /** @var mixed */
+    private $schema;
+
+    private function __construct($schema)
+    {
+        $this->schema = $schema;
+    }
+
+    public static function fromMemory(MemoryInterface $memory): self
+    {
+        return new self($memory->loadData(self::MEMORY_SECTION));
+    }
+
+    public static function compile(Registry $registry, array $generators, array $defaults = []): self
+    {
+        return new self((new Compiler())->compile($registry, $generators, $defaults));
+    }
+
+    public function isEmpty(): bool
+    {
+        return empty($this->schema);
+    }
+
+    public function toSchema(): SchemaInterface
+    {
+        return new Schema($this->isWriteableSchema() ? $this->schema : []);
+    }
+
+    public function toMemory(MemoryInterface $memory)
+    {
+        return $memory->saveData(
+            self::MEMORY_SECTION,
+            empty($this->schema) ? self::EMPTY_SCHEMA : $this->schema
+        );
+    }
+
+    private function isWriteableSchema(): bool
+    {
+        return is_array($this->schema) && $this->schema !== self::EMPTY_SCHEMA;
+    }
+}

--- a/app/src/Console/Command/CycleOrm/Generator/ShowChanges.php
+++ b/app/src/Console/Command/CycleOrm/Generator/ShowChanges.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Command\CycleOrm\Generator;
+
+use Cycle\Schema\GeneratorInterface;
+use Cycle\Schema\Registry;
+use Cycle\Database\Schema\AbstractTable;
+use Cycle\Database\Schema\Comparator;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class ShowChanges implements GeneratorInterface
+{
+    private array $changes = [];
+
+    public function __construct(
+        private OutputInterface $output
+    ) {
+    }
+
+    /**
+     * @param  Registry  $registry
+     * @return Registry
+     */
+    public function run(Registry $registry): Registry
+    {
+        $this->output->writeln('<info>Detecting schema changes:</info>');
+
+        $this->changes = [];
+        foreach ($registry->getIterator() as $e) {
+            if ($registry->hasTable($e)) {
+                $table = $registry->getTableSchema($e);
+
+                if ($table->getComparator()->hasChanges()) {
+                    $key = $registry->getDatabase($e).':'.$registry->getTable($e);
+                    $this->changes[$key] = [
+                        'database' => $registry->getDatabase($e),
+                        'table' => $registry->getTable($e),
+                        'schema' => $table,
+                    ];
+                }
+            }
+        }
+
+        if ($this->changes === []) {
+            $this->output->writeln('<fg=yellow>no database changes has been detected</fg=yellow>');
+
+            return $registry;
+        }
+
+        foreach ($this->changes as $change) {
+            $this->output->write(sprintf('• <fg=cyan>%s.%s</fg=cyan>', $change['database'], $change['table']));
+            $this->describeChanges($change['schema']);
+        }
+
+        return $registry;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasChanges(): bool
+    {
+        return $this->changes !== [];
+    }
+
+    /**
+     * @param  AbstractTable  $table
+     */
+    protected function describeChanges(AbstractTable $table): void
+    {
+        if (!$this->output->isVerbose()) {
+            $this->output->writeln(
+                sprintf(
+                    ': <fg=green>%s</fg=green> change(s) detected',
+                    $this->numChanges($table)
+                )
+            );
+
+            return;
+        }
+        $this->output->write("\n");
+
+
+        if (!$table->exists()) {
+            $this->output->writeln('    - create table');
+        }
+
+        if ($table->getStatus() === AbstractTable::STATUS_DECLARED_DROPPED) {
+            $this->output->writeln('    - drop table');
+            return;
+        }
+
+        $cmp = $table->getComparator();
+
+        $this->describeColumns($cmp);
+        $this->describeIndexes($cmp);
+        $this->describeFKs($cmp);
+    }
+
+    /**
+     * @param  Comparator  $cmp
+     */
+    protected function describeColumns(Comparator $cmp): void
+    {
+        foreach ($cmp->addedColumns() as $column) {
+            $this->output->writeln("    - add column <fg=yellow>{$column->getName()}</fg=yellow>");
+        }
+
+        foreach ($cmp->droppedColumns() as $column) {
+            $this->output->writeln("    - drop column <fg=yellow>{$column->getName()}</fg=yellow>");
+        }
+
+        foreach ($cmp->alteredColumns() as $column) {
+            $column = $column[0];
+            $this->output->writeln("    - alter column <fg=yellow>{$column->getName()}</fg=yellow>");
+        }
+    }
+
+    /**
+     * @param  Comparator  $cmp
+     */
+    protected function describeIndexes(Comparator $cmp): void
+    {
+        foreach ($cmp->addedIndexes() as $index) {
+            $index = implode(', ', $index->getColumns());
+            $this->output->writeln("    - add index on <fg=yellow>[{$index}]</fg=yellow>");
+        }
+
+        foreach ($cmp->droppedIndexes() as $index) {
+            $index = implode(', ', $index->getColumns());
+            $this->output->writeln("    - drop index on <fg=yellow>[{$index}]</fg=yellow>");
+        }
+
+        foreach ($cmp->alteredIndexes() as $index) {
+            $index = $index[0];
+            $index = implode(', ', $index->getColumns());
+            $this->output->writeln("    - alter index on <fg=yellow>[{$index}]</fg=yellow>");
+        }
+    }
+
+    /**
+     * @param  Comparator  $cmp
+     */
+    protected function describeFKs(Comparator $cmp): void
+    {
+        foreach ($cmp->addedForeignKeys() as $fk) {
+            $fkColumns = implode(', ', $fk->getColumns());
+            $this->output->writeln("    - add foreign key on <fg=yellow>{$fkColumns}</fg=yellow>");
+        }
+
+        foreach ($cmp->droppedForeignKeys() as $fk) {
+            $fkColumns = implode(', ', $fk->getColumns());
+            $this->output->writeln("    - drop foreign key <fg=yellow>{$fkColumns}</fg=yellow>");
+        }
+
+        foreach ($cmp->alteredForeignKeys() as $fk) {
+            $fk = $fk[0];
+            $fkColumns = implode(', ', $fk->getColumns());
+            $this->output->writeln("    - alter foreign key <fg=yellow>{$fkColumns}</fg=yellow>");
+        }
+    }
+
+    /**
+     * @param  AbstractTable  $table
+     * @return int
+     */
+    protected function numChanges(AbstractTable $table): int
+    {
+        $cmp = $table->getComparator();
+
+        return count($cmp->addedColumns())
+            + count($cmp->droppedColumns())
+            + count($cmp->alteredColumns())
+            + count($cmp->addedIndexes())
+            + count($cmp->droppedIndexes())
+            + count($cmp->alteredIndexes())
+            + count($cmp->addedForeignKeys())
+            + count($cmp->droppedForeignKeys())
+            + count($cmp->alteredForeignKeys());
+    }
+}

--- a/app/src/Console/Command/CycleOrm/MigrateCommand.php
+++ b/app/src/Console/Command/CycleOrm/MigrateCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Command\CycleOrm;
+
+use App\Bootloader\SchemaBootloader;
+use App\Console\Command\CycleOrm\Generator\ShowChanges;
+use App\Console\Command\Migrate\AbstractCommand;
+use Cycle\Migrations\State;
+use Cycle\Schema\Generator\Migrations\GenerateMigrations;
+use Cycle\Schema\Compiler;
+use Cycle\Schema\Registry;
+use Spiral\Boot\MemoryInterface;
+use Spiral\Console\Console;
+use Spiral\Cycle\SchemaCompiler;
+use Cycle\Migrations\Migrator;
+use Symfony\Component\Console\Input\InputOption;
+
+final class MigrateCommand extends AbstractCommand
+{
+    protected const NAME = 'cycle:migrate';
+    protected const DESCRIPTION = 'Generate ORM schema migrations';
+    protected const OPTIONS = [
+        ['run', 'r', InputOption::VALUE_NONE, 'Automatically run generated migration.'],
+    ];
+
+    public function perform(
+        SchemaBootloader $bootloader,
+        Registry $registry,
+        MemoryInterface $memory,
+        GenerateMigrations $migrations,
+        Migrator $migrator,
+        Console $console
+    ): void {
+        $migrator->configure();
+
+        foreach ($migrator->getMigrations() as $migration) {
+            if ($migration->getState()->getStatus() !== State::STATUS_EXECUTED) {
+                $this->writeln('<fg=red>Outstanding migrations found, run `migrate` first.</fg=red>');
+                return;
+            }
+        }
+
+        $show = new ShowChanges($this->output);
+        $schemaCompiler = SchemaCompiler::compile(
+            $registry,
+            array_merge($bootloader->getGenerators(), [$show])
+        );
+
+        $schemaCompiler->toMemory($memory);
+
+        if ($show->hasChanges()) {
+            (new Compiler())->compile($registry, [$migrations]);
+
+            if ($this->option('run')) {
+                $console->run('migrate', [], $this->output);
+            }
+        }
+    }
+}

--- a/app/src/Console/Command/CycleOrm/RenderCommand.php
+++ b/app/src/Console/Command/CycleOrm/RenderCommand.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Command\CycleOrm;
+
+use Cycle\ORM\SchemaInterface;
+use Cycle\Schema\Renderer\OutputSchemaRenderer;
+use Cycle\Schema\Renderer\SchemaToArrayConverter;
+use Spiral\Console\Command;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class RenderCommand extends Command
+{
+    protected const NAME = 'cycle:render';
+    protected const DESCRIPTION = 'Render available CycleORM schemas';
+
+    public function perform(
+        OutputInterface $output,
+        SchemaInterface $schema,
+        OutputSchemaRenderer $renderer,
+        SchemaToArrayConverter $converter
+    ): int {
+        $output->writeln(
+            $renderer->render(
+                $converter->convert($schema)
+            )
+        );
+
+        return 0;
+    }
+}

--- a/app/src/Console/Command/CycleOrm/SyncCommand.php
+++ b/app/src/Console/Command/CycleOrm/SyncCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Command\CycleOrm;
+
+use App\Bootloader\SchemaBootloader;
+use Cycle\Schema\Generator\SyncTables;
+use Cycle\Schema\Registry;
+use Spiral\Boot\MemoryInterface;
+use Spiral\Command\Cycle\Generator\ShowChanges;
+use Spiral\Console\Command;
+use Spiral\Cycle\SchemaCompiler;
+
+final class SyncCommand extends Command
+{
+    protected const NAME = 'cycle:sync';
+    protected const DESCRIPTION = 'Sync Cycle ORM schema with database without intermediate migration (risk operation)';
+
+    public function perform(
+        SchemaBootloader $bootloader,
+        Registry $registry,
+        MemoryInterface $memory
+    ): void {
+        $show = new ShowChanges($this->output);
+
+        $schemaCompiler = SchemaCompiler::compile(
+            $registry,
+            array_merge($bootloader->getGenerators(), [$show, new SyncTables()])
+        );
+        $schemaCompiler->toMemory($memory);
+
+        if ($show->hasChanges()) {
+            $this->writeln("\n<info>ORM Schema has been synchronized</info>");
+        }
+    }
+}

--- a/app/src/Console/Command/CycleOrm/UpdateCommand.php
+++ b/app/src/Console/Command/CycleOrm/UpdateCommand.php
@@ -12,7 +12,7 @@ use Spiral\Cycle\SchemaCompiler;
 
 final class UpdateCommand extends Command
 {
-    protected const NAME = 'cycle:update';
+    protected const NAME = 'cycle';
     protected const DESCRIPTION = 'Update (init) cycle schema from database and annotated classes';
 
     public function perform(

--- a/app/src/Console/Command/CycleOrm/UpdateCommand.php
+++ b/app/src/Console/Command/CycleOrm/UpdateCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Command\CycleOrm;
+
+use App\Bootloader\SchemaBootloader;
+use Cycle\Schema\Registry;
+use Spiral\Boot\MemoryInterface;
+use Spiral\Console\Command;
+use Spiral\Cycle\SchemaCompiler;
+
+final class UpdateCommand extends Command
+{
+    protected const NAME = 'cycle:update';
+    protected const DESCRIPTION = 'Update (init) cycle schema from database and annotated classes';
+
+    public function perform(
+        SchemaBootloader $bootloader,
+        Registry $registry,
+        MemoryInterface $memory
+    ): void {
+        $this->write('Updating ORM schema... ');
+
+        $schemaCompiler = SchemaCompiler::compile($registry, $bootloader->getGenerators());
+        $schemaCompiler->toMemory($memory);
+
+        $this->writeln('<info>done</info>');
+    }
+}

--- a/app/src/Console/Command/Database/ListCommand.php
+++ b/app/src/Console/Command/Database/ListCommand.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Command\Database;
+
+use Spiral\Console\Command;
+use Cycle\Database\Config\DatabaseConfig;
+use Cycle\Database\Database;
+use Cycle\Database\DatabaseManager;
+use Cycle\Database\Driver\Driver;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableSeparator;
+use Symfony\Component\Console\Input\InputArgument;
+
+final class ListCommand extends Command
+{
+    protected const NAME = 'db:list';
+    protected const DESCRIPTION = 'Get list of available databases, their tables and records count';
+    protected const ARGUMENTS = [
+        ['db', InputArgument::OPTIONAL, 'Database name'],
+    ];
+
+    /**
+     * @param  DatabaseConfig  $config
+     * @param  DatabaseManager  $dbal
+     */
+    public function perform(DatabaseConfig $config, DatabaseManager $dbal): void
+    {
+        if ($this->argument('db')) {
+            $databases = [$this->argument('db')];
+        } else {
+            $databases = array_keys($config->getDatabases());
+        }
+
+        if (empty($databases)) {
+            $this->writeln('<fg=red>No databases found.</fg=red>');
+
+            return;
+        }
+
+        $grid = $this->table(
+            [
+                'Name (ID):',
+                'Database:',
+                'Driver:',
+                'Prefix:',
+                'Status:',
+                'Tables:',
+                'Count Records:',
+            ]
+        );
+
+        foreach ($databases as $database) {
+            $database = $dbal->database($database);
+
+            /** @var Driver $driver */
+            $driver = $database->getDriver();
+
+            $header = [
+                $database->getName(),
+                $driver->getSource(),
+                $driver->getType(),
+                $database->getPrefix() ?: '<comment>---</comment>',
+            ];
+
+            try {
+                $driver->connect();
+            } catch (\Exception $exception) {
+                $this->renderException($grid, $header, $exception);
+
+                if ($database->getName() != end($databases)) {
+                    $grid->addRow(new TableSeparator());
+                }
+
+                continue;
+            }
+
+            $header[] = '<info>connected</info>';
+            $this->renderTables($grid, $header, $database);
+            if ($database->getName() != end($databases)) {
+                $grid->addRow(new TableSeparator());
+            }
+        }
+
+        $grid->render();
+    }
+
+    /**
+     * @param  Table  $grid
+     * @param  array  $header
+     * @param  \Throwable  $exception
+     */
+    private function renderException(Table $grid, array $header, \Throwable $exception): void
+    {
+        $grid->addRow(
+            array_merge(
+                $header,
+                [
+                    "<fg=red>{$exception->getMessage()}</fg=red>",
+                    '<comment>---</comment>',
+                    '<comment>---</comment>',
+                ]
+            )
+        );
+    }
+
+    /**
+     * @param  Table  $grid
+     * @param  array  $header
+     * @param  Database  $database
+     */
+    private function renderTables(Table $grid, array $header, Database $database): void
+    {
+        foreach ($database->getTables() as $table) {
+            $grid->addRow(
+                array_merge(
+                    $header,
+                    [$table->getName(), number_format($table->count())]
+                )
+            );
+            $header = ['', '', '', '', ''];
+        }
+
+        $header[1] && $grid->addRow(array_merge($header, ['no tables', 'no records']));
+    }
+}

--- a/app/src/Console/Command/Database/TableCommand.php
+++ b/app/src/Console/Command/Database/TableCommand.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Command\Database;
+
+use Spiral\Console\Command;
+use Cycle\Database\Database;
+use Cycle\Database\DatabaseManager;
+use Cycle\Database\Driver\DriverInterface;
+use Cycle\Database\Exception\DBALException;
+use Cycle\Database\Injection\FragmentInterface;
+use Cycle\Database\Query\QueryParameters;
+use Cycle\Database\Schema\AbstractColumn;
+use Cycle\Database\Schema\AbstractTable;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+final class TableCommand extends Command
+{
+    protected const NAME = 'db:table';
+    protected const DESCRIPTION = 'Describe table schema of specific database';
+    protected const ARGUMENTS = [
+        ['table', InputArgument::REQUIRED, 'Table name'],
+    ];
+    protected const OPTIONS = [
+        ['database', 'db', InputOption::VALUE_OPTIONAL, 'Source database', 'default'],
+    ];
+
+    private const SKIP = '<comment>---</comment>';
+
+    public function perform(DatabaseManager $dbal): void
+    {
+        $database = $dbal->database($this->option('database'));
+        $schema = $database->table($this->argument('table'))->getSchema();
+
+        if (!$schema->exists()) {
+            throw new DBALException(
+                "Table {$database->getName()}.{$this->argument('table')} does not exists."
+            );
+        }
+
+        $this->sprintf(
+            "\n<fg=cyan>Columns of </fg=cyan><comment>%s.%s</comment>:\n",
+            $database->getName(),
+            $this->argument('table')
+        );
+
+        $this->describeColumns($schema);
+
+        if (!empty($indexes = $schema->getIndexes())) {
+            $this->describeIndexes($database, $indexes);
+        }
+
+        if (!empty($foreignKeys = $schema->getForeignKeys())) {
+            $this->describeForeignKeys($database, $foreignKeys);
+        }
+
+        $this->write("\n");
+    }
+
+    protected function describeColumns(AbstractTable $schema): void
+    {
+        $columnsTable = $this->table(
+            [
+                'Column:',
+                'Database Type:',
+                'Abstract Type:',
+                'PHP Type:',
+                'Default Value:',
+            ]
+        );
+
+        foreach ($schema->getColumns() as $column) {
+            $name = $column->getName();
+
+            if (in_array($column->getName(), $schema->getPrimaryKeys(), true)) {
+                $name = "<fg=magenta>{$name}</fg=magenta>";
+            }
+
+            $defaultValue = $this->describeDefaultValue($column, $schema->getDriver());
+
+            $columnsTable->addRow(
+                [
+                    $name,
+                    $this->describeType($column),
+                    $this->describeAbstractType($column),
+                    $column->getType(),
+                    $defaultValue ?? self::SKIP,
+                ]
+            );
+        }
+
+        $columnsTable->render();
+    }
+
+    protected function describeIndexes(Database $database, array $indexes): void
+    {
+        $this->sprintf(
+            "\n<fg=cyan>Indexes of </fg=cyan><comment>%s.%s</comment>:\n",
+            $database->getName(),
+            $this->argument('table')
+        );
+
+        $indexesTable = $this->table(['Name:', 'Type:', 'Columns:']);
+        foreach ($indexes as $index) {
+            $indexesTable->addRow(
+                [
+                    $index->getName(),
+                    $index->isUnique() ? 'UNIQUE INDEX' : 'INDEX',
+                    implode(', ', $index->getColumns()),
+                ]
+            );
+        }
+
+        $indexesTable->render();
+    }
+
+    protected function describeForeignKeys(Database $database, array $foreignKeys): void
+    {
+        $this->sprintf(
+            "\n<fg=cyan>Foreign Keys of </fg=cyan><comment>%s.%s</comment>:\n",
+            $database->getName(),
+            $this->argument('table')
+        );
+        $foreignTable = $this->table(
+            [
+                'Name:',
+                'Column:',
+                'Foreign Table:',
+                'Foreign Column:',
+                'On Delete:',
+                'On Update:',
+            ]
+        );
+
+        foreach ($foreignKeys as $reference) {
+            $foreignTable->addRow(
+                [
+                    $reference->getName(),
+                    implode(', ', $reference->getColumns()),
+                    $reference->getForeignTable(),
+                    implode(', ', $reference->getForeignKeys()),
+                    $reference->getDeleteRule(),
+                    $reference->getUpdateRule(),
+                ]
+            );
+        }
+
+        $foreignTable->render();
+    }
+
+    protected function describeDefaultValue(AbstractColumn $column, DriverInterface $driver)
+    {
+        $defaultValue = $column->getDefaultValue();
+
+        if ($defaultValue instanceof FragmentInterface) {
+            $value = $driver->getQueryCompiler()->compile(new QueryParameters(), '', $defaultValue);
+
+            return "<info>{$value}</info>";
+        }
+
+        if ($defaultValue instanceof \DateTimeInterface) {
+            $defaultValue = $defaultValue->format('c');
+        }
+
+        return $defaultValue;
+    }
+
+    private function describeType(AbstractColumn $column): string
+    {
+        $type = $column->getType();
+
+        $abstractType = $column->getAbstractType();
+
+        if ($column->getSize()) {
+            $type .= " ({$column->getSize()})";
+        }
+
+        if ($abstractType === 'decimal') {
+            $type .= " ({$column->getPrecision()}, {$column->getScale()})";
+        }
+
+        return $type;
+    }
+
+    private function describeAbstractType(AbstractColumn $column): string
+    {
+        $abstractType = $column->getAbstractType();
+
+        if (in_array($abstractType, ['primary', 'bigPrimary'])) {
+            $abstractType = "<fg=magenta>{$abstractType}</fg=magenta>";
+        }
+
+        return $abstractType;
+    }
+}
+

--- a/app/src/Console/Command/Migrate/AbstractCommand.php
+++ b/app/src/Console/Command/Migrate/AbstractCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Command\Migrate;
+
+use Spiral\Console\Command;
+use Cycle\Migrations\Config\MigrationConfig;
+use Cycle\Migrations\Migrator;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+abstract class AbstractCommand extends Command
+{
+    public function __construct(
+        protected Migrator $migrator,
+        protected MigrationConfig $config
+    ) {
+        parent::__construct();
+    }
+
+    protected function verifyConfigured(): bool
+    {
+        if (!$this->migrator->isConfigured()) {
+            $this->writeln(
+                "<fg=red>Migrations are not configured yet, run '<info>migrate:init</info>' first.</fg=red>"
+            );
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if current environment is safe to run migration.
+     */
+    protected function verifyEnvironment(): bool
+    {
+        if ($this->option('force') || $this->config->isSafe()) {
+            //Safe to run
+            return true;
+        }
+
+        $this->writeln('<fg=red>Confirmation is required to run migrations!</fg=red>');
+
+        if (!$this->askConfirmation()) {
+            $this->writeln('<comment>Cancelling operation...</comment>');
+
+            return false;
+        }
+
+        return true;
+    }
+
+    protected function defineOptions(): array
+    {
+        return array_merge(
+            static::OPTIONS,
+            [
+                ['force', 's', InputOption::VALUE_NONE, 'Skip safe environment check'],
+            ]
+        );
+    }
+
+    protected function askConfirmation(): bool
+    {
+        $question = new QuestionHelper();
+
+        return $question->ask(
+            $this->input,
+            $this->output,
+            new ConfirmationQuestion('<question>Would you like to continue?</question> ')
+        );
+    }
+}

--- a/app/src/Console/Command/Migrate/InitCommand.php
+++ b/app/src/Console/Command/Migrate/InitCommand.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Command\Migrate;
+
+final class InitCommand extends AbstractCommand
+{
+    protected const NAME = 'migrate:init';
+    protected const DESCRIPTION = 'Init migrations component (create migrations table)';
+
+    /**
+     * Perform command.
+     */
+    public function perform(): void
+    {
+        $this->migrator->configure();
+        $this->writeln('<info>Migrations table were successfully created</info>');
+    }
+}

--- a/app/src/Console/Command/Migrate/MigrateCommand.php
+++ b/app/src/Console/Command/Migrate/MigrateCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Command\Migrate;
+
+use Symfony\Component\Console\Input\InputOption;
+
+final class MigrateCommand extends AbstractCommand
+{
+    protected const NAME = 'migrate';
+    protected const DESCRIPTION = 'Perform one or all outstanding migrations';
+    protected const OPTIONS = [
+        ['one', 'o', InputOption::VALUE_NONE, 'Execute only one (first) migration'],
+    ];
+
+    /**
+     * Execute one or multiple migrations.
+     */
+    public function perform(): void
+    {
+        if (!$this->verifyEnvironment()) {
+            return;
+        }
+
+        $this->migrator->configure();
+
+        $found = false;
+        $count = $this->option('one') ? 1 : PHP_INT_MAX;
+
+        while ($count > 0 && ($migration = $this->migrator->run())) {
+            $found = true;
+            $count--;
+
+            $this->sprintf(
+                "<info>Migration <comment>%s</comment> was successfully executed.</info>\n",
+                $migration->getState()->getName()
+            );
+        }
+
+        if (!$found) {
+            $this->writeln('<fg=red>No outstanding migrations were found.</fg=red>');
+        }
+    }
+}

--- a/app/src/Console/Command/Migrate/ReplayCommand.php
+++ b/app/src/Console/Command/Migrate/ReplayCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Command\Migrate;
+
+use Spiral\Console\Console;
+use Symfony\Component\Console\Input\InputOption;
+
+final class ReplayCommand extends AbstractCommand
+{
+    protected const NAME = 'migrate:replay';
+    protected const DESCRIPTION = 'Replay (down, up) one or multiple migrations';
+    protected const OPTIONS = [
+        ['all', 'a', InputOption::VALUE_NONE, 'Replay all migrations.'],
+    ];
+
+    /**
+     * @param  Console  $console
+     * @throws \Throwable
+     */
+    public function perform(Console $console): void
+    {
+        if (!$this->verifyEnvironment()) {
+            //Making sure we can safely migrate in this environment
+            return;
+        }
+
+        $rollback = ['--force' => true];
+        $migrate = ['--force' => true];
+
+        if ($this->option('all')) {
+            $rollback['--all'] = true;
+        } else {
+            $migrate['--one'] = true;
+        }
+
+        $this->writeln('Rolling back executed migration(s)...');
+        $console->run('migrate:rollback', $rollback, $this->output);
+
+        $this->writeln('');
+
+        $this->writeln('Executing outstanding migration(s)...');
+        $console->run('migrate', $migrate, $this->output);
+    }
+}

--- a/app/src/Console/Command/Migrate/RollbackCommand.php
+++ b/app/src/Console/Command/Migrate/RollbackCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Command\Migrate;
+
+use Symfony\Component\Console\Input\InputOption;
+
+final class RollbackCommand extends AbstractCommand
+{
+    protected const NAME = 'migrate:rollback';
+    protected const DESCRIPTION = 'Rollback one (default) or multiple migrations';
+    protected const OPTIONS = [
+        ['all', 'a', InputOption::VALUE_NONE, 'Rollback all executed migrations'],
+    ];
+
+    public function perform(): void
+    {
+        if (!$this->verifyEnvironment()) {
+            //Making sure we can safely migrate in this environment
+            return;
+        }
+
+        $this->migrator->configure();
+
+        $found = false;
+        $count = !$this->option('all') ? 1 : PHP_INT_MAX;
+        while ($count > 0 && ($migration = $this->migrator->rollback())) {
+            $found = true;
+            $count--;
+            $this->sprintf(
+                "<info>Migration <comment>%s</comment> was successfully rolled back.</info>\n",
+                $migration->getState()->getName()
+            );
+        }
+
+        if (!$found) {
+            $this->writeln('<fg=red>No executed migrations were found.</fg=red>');
+        }
+    }
+}

--- a/app/src/Console/Command/Migrate/StatusCommand.php
+++ b/app/src/Console/Command/Migrate/StatusCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Command\Migrate;
+
+use Spiral\Files\FilesInterface;
+use Spiral\Migrations\State;
+
+/**
+ * Show all available migrations and their statuses
+ */
+final class StatusCommand extends AbstractCommand
+{
+    protected const NAME = 'migrate:status';
+    protected const DESCRIPTION = 'Get list of all available migrations and their statuses';
+    protected const PENDING = '<fg=red>not executed yet</fg=red>';
+
+    public function perform(FilesInterface $files): void
+    {
+        $this->migrator->configure();
+
+        if (empty($this->migrator->getMigrations())) {
+            $this->writeln('<comment>No migrations were found.</comment>');
+
+            return;
+        }
+
+        $table = $this->table(['Migration', 'Created at', 'Executed at']);
+        foreach ($this->migrator->getMigrations() as $migration) {
+            $state = $migration->getState();
+
+            $table->addRow(
+                [
+                    $state->getName(),
+                    $state->getTimeCreated()->format('Y-m-d H:i:s'),
+                    $state->getStatus() == State::STATUS_PENDING
+                        ? self::PENDING
+                        : '<info>'.$state->getTimeExecuted()->format('Y-m-d H:i:s').'</info>',
+                ]
+            );
+        }
+
+        $table->render();
+    }
+}

--- a/app/src/Controller/HomeController.php
+++ b/app/src/Controller/HomeController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of Spiral package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 declare(strict_types=1);
 
 namespace App\Controller;

--- a/app/src/Cycle/FinalClassMapperFixerGenerator.php
+++ b/app/src/Cycle/FinalClassMapperFixerGenerator.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Cycle;
+
+use Cycle\ORM\Mapper\PromiseMapper;
+use Cycle\Schema\GeneratorInterface;
+use Cycle\Schema\Registry;
+
+class FinalClassMapperFixerGenerator implements GeneratorInterface
+{
+    public function run(Registry $registry): Registry
+    {
+        // Final class can only work with PromiseMapper
+        foreach ($registry as $entity) {
+            if (!$entity->getClass()) {
+                continue;
+            }
+
+
+            $class = new \ReflectionClass($entity->getClass());
+            if ($class->isFinal() && !$entity->getMapper()) {
+                $entity->setMapper(PromiseMapper::class);
+            }
+        }
+
+        return $registry;
+    }
+}

--- a/app/src/Entity/User.php
+++ b/app/src/Entity/User.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use Cycle\Annotated\Annotation\Column;
+use Cycle\Annotated\Annotation\Entity;
+
+#[Entity]
+class User
+{
+    #[Column(type: 'int', primary: true)]
+    private int $id;
+
+    public function __construct(
+        #[Column(type: 'string', name: 'username')]
+        private string $name,
+
+        #[Column(type: 'enum(active,disabled)')]
+        private string $status,
+
+        #[Column(type: 'string(64)', nullable: true)]
+        private ?string $password = null,
+    ) {
+    }
+}

--- a/app/src/Job/Ping.php
+++ b/app/src/Job/Ping.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of Spiral package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 declare(strict_types=1);
 
 namespace App\Job;
@@ -18,10 +11,6 @@ use Spiral\Jobs\JobHandler;
  */
 class Ping extends JobHandler
 {
-    /**
-     * @param string $id
-     * @param string $value
-     */
     public function invoke(string $id, string $value): void
     {
         // do something

--- a/app/src/Middleware/LocaleSelector.php
+++ b/app/src/Middleware/LocaleSelector.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of Spiral package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 declare(strict_types=1);
 
 namespace App\Middleware;
@@ -19,30 +12,14 @@ use Spiral\Translator\Translator;
 
 class LocaleSelector implements MiddlewareInterface
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    /** @var string[] */
+    private array $availableLocales;
 
-    /**
-     * @var string[]
-     */
-    private $availableLocales;
-
-    /**
-     * @param Translator $translator
-     */
-    public function __construct(Translator $translator)
+    public function __construct(private Translator $translator)
     {
-        $this->translator = $translator;
         $this->availableLocales = $this->translator->getCatalogueManager()->getLocales();
     }
 
-    /**
-     * @param ServerRequestInterface  $request
-     * @param RequestHandlerInterface $handler
-     * @return ResponseInterface
-     */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $defaultLocale = $this->translator->getLocale();
@@ -62,10 +39,6 @@ class LocaleSelector implements MiddlewareInterface
         }
     }
 
-    /**
-     * @param ServerRequestInterface $request
-     * @return \Generator
-     */
     public function fetchLocales(ServerRequestInterface $request): \Generator
     {
         $header = $request->getHeaderLine('accept-language');

--- a/composer.json
+++ b/composer.json
@@ -15,21 +15,26 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": ">=8.0",
         "ext-mbstring": "*",
+        "cycle/annotated": "2.0.x-dev",
+        "cycle/migrations": "2.0.x-dev",
+        "cycle/orm": "2.0.x-dev",
+        "cycle/schema-migrations-generator": "dev-master",
+        "cycle/schema-renderer": "^1.0",
         "spiral/framework": "^2.8",
         "spiral/jobs": "^2.0",
-        "spiral/roadrunner": "^1.4",
-        "spiral/database": "^2.3",
         "spiral/migrations": "^2.0",
         "spiral/nyholm-bridge": "^1.0",
-        "cycle/orm": "^1.0",
-        "cycle/proxy-factory": "^1.0",
-        "cycle/annotated": "^2.0",
-        "cycle/migrations": "^1.0"
+        "spiral/roadrunner": "^1.4",
+        "spiral/sentry-bridge": "^1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5|^9.0"
+    },
+    "suggest": {
+        "doctrine/collections": "Required to use CycleORM doctrine collections for relations via DoctrineCollectionFactory",
+        "illuminate/collections": "Required to use CycleORM illuminate collections for relations via IlluminateCollectionFactory"
     },
     "scripts": {
         "post-create-project-cmd": [


### PR DESCRIPTION
- Replaced spiral/database with cycle/database 2.0-x-dev
- Replaced cycle/orm v1.0 with cycle/orm 2.0-x-dev
- Replaced cycle/migrations v1.0 with cycle/migrations 2.0-x-dev
- Removed cycle/proxy-factory
- Minimal PHP version bumped up to 8.0
- Added cycle/schema-renderer. Use `cycle:render` console command

**This is a pre-release and all system bootloaders and console commands will be moved into Spiral framework**