### PR TITLE
Sort bootloaders so that dotenv bootloader is loaded before the others

### DIFF
--- a/app/src/App.php
+++ b/app/src/App.php
@@ -30,6 +30,9 @@ class App extends Kernel
      * within system container on application start.
      */
     protected const LOAD = [
+        // Base extensions
+        DotEnv\DotenvBootloader::class,
+        Monolog\MonologBootloader::class,
 
         // RoadRunner
         RoadRunnerBridge\CacheBootloader::class,
@@ -37,10 +40,6 @@ class App extends Kernel
         RoadRunnerBridge\HttpBootloader::class,
         RoadRunnerBridge\QueueBootloader::class,
         RoadRunnerBridge\RoadRunnerBootloader::class,
-
-        // Base extensions
-        DotEnv\DotenvBootloader::class,
-        Monolog\MonologBootloader::class,
 
         // Application specific logs
         Bootloader\LoggingBootloader::class,

--- a/composer.json
+++ b/composer.json
@@ -52,10 +52,7 @@
         }
     },
     "config": {
-        "sort-packages": true,
-        "allow-plugins": {
-            "spiral/composer-publish-plugin": true
-        }
+        "sort-packages": true
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,10 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "spiral/composer-publish-plugin": true
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true


### PR DESCRIPTION
Since `DotenvBootloader` is loaded later than bootloaders like `Spiral\RoadRunnerBridge\Bootloader\CacheBootloader`, `Spiral\RoadRunnerBridge\Bootloader\QueueBootloader`, they have no access to environment variables, so the default settings get default values. Because of this there is no way to override variables like `QUEUE_CONNECTION`, `CACHE_STORAGE`, etc.