### PR TITLE
Removing spiral/nyholm-bridge

### DIFF
--- a/app/src/App.php
+++ b/app/src/App.php
@@ -9,7 +9,6 @@ use Spiral\Bootloader as Framework;
 use Spiral\DotEnv\Bootloader as DotEnv;
 use Spiral\Framework\Kernel;
 use Spiral\Monolog\Bootloader as Monolog;
-use Spiral\Nyholm\Bootloader as Nyholm;
 use Spiral\Prototype\Bootloader as Prototype;
 use Spiral\Sapi\Bootloader\SapiBootloader;
 use Spiral\Scaffolder\Bootloader as Scaffolder;
@@ -52,7 +51,6 @@ class App extends Kernel
         Framework\Security\GuardBootloader::class,
 
         // HTTP extensions
-        Nyholm\NyholmBootloader::class,
         Framework\Http\RouterBootloader::class,
         Framework\Http\ErrorHandlerBootloader::class,
         Framework\Http\JsonPayloadsBootloader::class,

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "doctrine/collections": "^1.6",
         "spiral/cycle-bridge": "^2.0",
         "spiral/framework": "3.0.x-dev",
-        "spiral/nyholm-bridge": "^1.2",
         "spiral/roadrunner-bridge": "^2.0",
         "spiral/sapi-bridge": "^1.0",
         "symfony/var-dumper": "^6.0"


### PR DESCRIPTION
SF 3.0 already includes `nyholm/psr7`:
https://github.com/spiral/framework/blob/3.0/src/Http/src/Bootloader/DiactorosBootloader.php