### PR TITLE
Fixing demo Ping job

### DIFF
--- a/app/src/App.php
+++ b/app/src/App.php
@@ -107,14 +107,14 @@ class App extends Kernel
         Framework\Debug\HttpCollectorBootloader::class,
 
         RoadRunnerBridge\CommandBootloader::class,
+
+        Bootloader\RoutesBootloader::class,
     ];
 
     /*
      * Application specific services and extensions.
      */
     protected const APP = [
-        Bootloader\RoutesBootloader::class,
-
         // fast code prototyping
         Prototype\PrototypeBootloader::class,
     ];

--- a/app/src/Bootloader/LoggingBootloader.php
+++ b/app/src/Bootloader/LoggingBootloader.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of Spiral package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 declare(strict_types=1);
 
 namespace App\Bootloader;

--- a/app/src/Controller/HomeController.php
+++ b/app/src/Controller/HomeController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of Spiral package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 declare(strict_types=1);
 
 namespace App\Controller;

--- a/app/src/Job/Ping.php
+++ b/app/src/Job/Ping.php
@@ -1,28 +1,19 @@
 <?php
 
-/**
- * This file is part of Spiral package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 declare(strict_types=1);
 
 namespace App\Job;
 
 use Spiral\Queue\JobHandler;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * (QueueInterface)->push(PingJob::class, ["value"=>"my value"]);
  */
 class Ping extends JobHandler
 {
-    public function invoke(HttpClientInterface $client, string $url): void
+    public function invoke(array $payload): void
     {
         // do something
-        $status = $client->request('GET', $url)->getStatusCode() === 200;
-        echo $status ? 'PONG' : 'ERROR';
+        echo $payload['value'];
     }
 }

--- a/app/src/Middleware/LocaleSelector.php
+++ b/app/src/Middleware/LocaleSelector.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of Spiral package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 declare(strict_types=1);
 
 namespace App\Middleware;


### PR DESCRIPTION
Error:
`[App\Job\Ping] Undefined class or binding Symfony\Contracts\HttpClient\HttpClientInterface`

There is no `Symfony\Contracts\HttpClient\HttpClientInterface` binding in the container. And I don't think we should add it. Therefore, I simplified the `Ping` job.