### PR TITLE
Show a error stack trace under DEBUG environments

### DIFF
--- a/app/views/exception/error.dark.php
+++ b/app/views/exception/error.dark.php
@@ -18,14 +18,14 @@
             </div>
 
             @if ($exception && env('DEBUG') === true)
-                <div style="display: flex; flex-direction: column; gap: 20px;">
+                <section style="display: flex; flex-direction: column; gap: 20px;" aria-label="Stack Trace">
                     @while($exception)
-                    <section style="max-width: 100%; overflow: auto; background: #efefef; padding: 5px 20px;">
-                        <h3>{{ $exception->getMessage() }}</h3>
-                        <pre style="word-break: break-all">{{ $exception->getTraceAsString() }}</pre>
-                    </section>
+                        <section style="max-width: 100%; overflow: auto; background: #efefef; padding: 5px 20px;">
+                            <h3>{{ $exception->getMessage() }}</h3>
+                            <pre>{{ $exception->getTraceAsString() }}</pre>
+                        </section>
 
-                    @php $exception = $exception->getPrevious(); @endphp
+                        @php $exception = $exception->getPrevious(); @endphp
                     @endwhile
                 </div>
             @endif

--- a/app/views/exception/error.dark.php
+++ b/app/views/exception/error.dark.php
@@ -16,6 +16,19 @@
             <div style="font-size: 12px; margin-top: 10px;">
                 [[This view file is located in]] <b>app/views/exception/error.dark.php</b>.
             </div>
+
+            @if ($exception && env('DEBUG') === true)
+                <div style="display: flex; flex-direction: column; gap: 20px;">
+                    @while($exception)
+                    <section style="max-width: 100%; overflow: auto; background: #efefef; padding: 5px 20px;">
+                        <h3>{{ $exception->getMessage() }}</h3>
+                        <pre style="word-break: break-all">{{ $exception->getTraceAsString() }}</pre>
+                    </section>
+
+                    @php $exception = $exception->getPrevious(); @endphp
+                    @endwhile
+                </div>
+            @endif
         </div>
     </div>
 </define:body>


### PR DESCRIPTION
This is just a little prototype. But it would be nice that the default error templat does shown a stack trace under development.