### PR TITLE
Add "composer serve" script to start the webserver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,10 @@
             "php app.php configure -vv",
             "rr get-binary"
         ],
+        "serve": [
+          "Composer\\Config::disableProcessTimeout",
+          "rr serve"
+        ],
         "psalm": "psalm"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
The `serve` script would be start the webserver, like in other frameworks skeleton.

References in Yii and Mezzio Framework:

 - https://github.com/mezzio/mezzio-skeleton/blob/4f60efe8a5d96b0178d446268c6fc2586f88df6b/composer.json#LL113C11-L117C11
 - https://github.com/yiisoft/app/blob/264163b2af0d90217291a4e5977411173fe72add/composer.json#L12-L15