### PR TITLE
Adding `functions.php` helper with `dd` function

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -14,7 +14,7 @@ if (!\function_exists('dd')) {
 
         foreach ($vars as $var) {
             $throwable->addDump(
-                $dumper->dump((new VarCloner)->cloneVar($var), true)
+                $dumper->dump((new VarCloner())->cloneVar($var), true)
             );
         }
 

--- a/functions.php
+++ b/functions.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Spiral\Debug\Exception\DumpException;
+use Spiral\Debug\HtmlDumper;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+
+if (!\function_exists('dd')) {
+    function dd(mixed ...$vars): mixed
+    {
+        $dumper = new HtmlDumper();
+        $throwable = new DumpException();
+
+        foreach ($vars as $var) {
+            $throwable->addDump(
+                $dumper->dump((new VarCloner)->cloneVar($var), true)
+            );
+        }
+
+        throw $throwable;
+    }
+}

--- a/installer/Application/Common/resources/app.php
+++ b/installer/Application/Common/resources/app.php
@@ -12,7 +12,7 @@ use App\Application\Kernel;
 \error_reporting((E_ALL | E_STRICT) ^ E_DEPRECATED);
 \ini_set('display_errors', 'stderr');
 
-// Application helper functions. Must be included before composer's autoloader.
+// Application helper functions. Must be included before the composer autoloader.
 require __DIR__ . '/functions.php';
 
 // Register Composer's auto loader.

--- a/installer/Application/Common/resources/app.php
+++ b/installer/Application/Common/resources/app.php
@@ -12,6 +12,9 @@ use App\Application\Kernel;
 \error_reporting((E_ALL | E_STRICT) ^ E_DEPRECATED);
 \ini_set('display_errors', 'stderr');
 
+// Application helper functions. Must be included before composer's autoloader.
+require __DIR__ . '/functions.php';
+
 // Register Composer's auto loader.
 require __DIR__ . '/vendor/autoload.php';
 

--- a/installer/Application/ComposerPackages.php
+++ b/installer/Application/ComposerPackages.php
@@ -11,7 +11,7 @@ enum ComposerPackages: string
     case ExtGRPC = 'ext-grpc:*';
     case ExtSockets = 'ext-sockets:*';
     case GRPC = 'grpc/grpc:^1.42';
-    case Dumper = 'dev:spiral/dumper:^3.0';
+    case Dumper = 'dev:spiral/dumper:^3.2';
     case RoadRunnerBridge = 'spiral/roadrunner-bridge:^3.0';
     case RoadRunnerCli = 'spiral/roadrunner-cli:^2.5';
     case NyholmBridge = 'spiral/nyholm-bridge:^1.3';

--- a/installer/Module/Exception/resources/app.php
+++ b/installer/Module/Exception/resources/app.php
@@ -13,6 +13,9 @@ use App\Application\Exception\Handler;
 \error_reporting((E_ALL | E_STRICT) ^ E_DEPRECATED);
 \ini_set('display_errors', 'stderr');
 
+// Application helper functions. Must be included before composer's autoloader.
+require __DIR__ . '/functions.php';
+
 // Register Composer's auto loader.
 require __DIR__ . '/vendor/autoload.php';
 

--- a/installer/Module/Exception/resources/app.php
+++ b/installer/Module/Exception/resources/app.php
@@ -13,7 +13,7 @@ use App\Application\Exception\Handler;
 \error_reporting((E_ALL | E_STRICT) ^ E_DEPRECATED);
 \ini_set('display_errors', 'stderr');
 
-// Application helper functions. Must be included before composer's autoloader.
+// Application helper functions. Must be included before the composer autoloader.
 require __DIR__ . '/functions.php';
 
 // Register Composer's auto loader.

--- a/installer/Tests/Unit/Internal/Installer/ComposerFileTest.php
+++ b/installer/Tests/Unit/Internal/Installer/ComposerFileTest.php
@@ -94,7 +94,7 @@ final class ComposerFileTest extends TestCase
             ->withArgs(static function (array $json): bool {
                 return
                     $json['require']['ext-grpc'] === '*'
-                    && $json['require-dev']['spiral/dumper'] === '^3.0'
+                    && $json['require-dev']['spiral/dumper'] === '^3.2'
                     && \in_array('ext-grpc', $json['extra']['spiral']['packages'])
                     && \in_array('spiral/dumper', $json['extra']['spiral']['packages']);
             });


### PR DESCRIPTION
### What was changed

Added the ability to use the popular debugging function **dd**.

```php
#[Route(route: '/', name: 'index')]
public function index(): string
{
    dd('Hello World');

    return $this->views->render('home');
}
```

Result:

<img width="615" alt="111" src="https://github.com/spiral/app/assets/67324318/6440537b-e44f-4560-846a-c9804c5890e5">
