### PR TITLE
Adding environment variables, removing unused bootloaders from Kernel

### DIFF
--- a/installer/Application/Common/resources/app/src/Application/Kernel.php
+++ b/installer/Application/Common/resources/app/src/Application/Kernel.php
@@ -10,17 +10,11 @@ use Spiral\DotEnv\Bootloader\DotenvBootloader;
 use Spiral\Monolog\Bootloader\MonologBootloader;
 use Spiral\Nyholm\Bootloader\NyholmBootloader;
 use Spiral\Prototype\Bootloader\PrototypeBootloader;
-use Spiral\RoadRunnerBridge\Bootloader as RoadRunnerBridge;
 use Spiral\Scaffolder\Bootloader\ScaffolderBootloader;
 use Spiral\Tokenizer\Bootloader\TokenizerListenerBootloader;
-use Spiral\YiiErrorHandler\Bootloader\YiiErrorHandlerBootloader;
 
 class Kernel extends \Spiral\Framework\Kernel
 {
-    protected const SYSTEM = [];
-    protected const LOAD = [];
-    protected const APP = [];
-
     public function defineSystemBootloaders(): array
     {
         return [
@@ -35,15 +29,10 @@ class Kernel extends \Spiral\Framework\Kernel
         return [
             // Logging and exceptions handling
             MonologBootloader::class,
-            YiiErrorHandlerBootloader::class,
             Bootloader\ExceptionHandlerBootloader::class,
 
             // Application specific logs
             Bootloader\LoggingBootloader::class,
-
-            // RoadRunner
-            RoadRunnerBridge\LoggerBootloader::class,
-            RoadRunnerBridge\HttpBootloader::class,
 
             // Core Services
             Framework\SnapshotsBootloader::class,
@@ -65,7 +54,6 @@ class Kernel extends \Spiral\Framework\Kernel
 
             // Console commands
             Framework\CommandBootloader::class,
-            RoadRunnerBridge\CommandBootloader::class,
             ScaffolderBootloader::class,
 
             // Configure route groups, middleware for route groups

--- a/installer/Application/Common/resources/phpunit.xml
+++ b/installer/Application/Common/resources/phpunit.xml
@@ -27,11 +27,14 @@
     </source>
     <php>
         <env name="DB_CONNECTION" value="sqlite" />
+        <env name="DB_LOG_QUERY_PARAMETERS" value="true" />
+        <env name="CYCLE_SCHEMA_CACHE" value="true" />
         <env name="QUEUE_CONNECTION" value="sync" />
         <env name="CACHE_STORAGE" value="local" />
         <env name="APP_ENV" value="testing" />
         <env name="TOKENIZER_CACHE_TARGETS" value="true" />
         <env name="TELEMETRY_DRIVER" value="null" />
+        <env name="BROADCAST_DRIVER" value="log" />
         <ini name="error_reporting" value="-1"/>
         <ini name="memory_limit" value="-1"/>
     </php>

--- a/installer/Module/CycleBridge/Generator/Env.php
+++ b/installer/Module/CycleBridge/Generator/Env.php
@@ -31,6 +31,8 @@ final class Env implements GeneratorInterface
         $context->envConfigurator->addGroup(
             values: [
                 'DB_CONNECTION' => 'sqlite',
+                'DB_LOG_QUERY_PARAMETERS' => false,
+                'DB_WITH_DATETIME_MICROSECONDS' => false,
             ],
             comment: 'Database',
             priority: 13,

--- a/installer/Module/CycleBridge/resources/config/database.php
+++ b/installer/Module/CycleBridge/resources/config/database.php
@@ -52,7 +52,11 @@ return [
     'drivers' => [
         'sqlite' => new Config\SQLiteDriverConfig(
             connection: new Config\SQLite\MemoryConnectionConfig(),
-            queryCache: true
+            queryCache: env('DB_QUERY_CACHE', true),
+            options: [
+                'logQueryParameters' => env('DB_LOG_QUERY_PARAMETERS', false),
+                'withDatetimeMicroseconds' => env('DB_WITH_DATETIME_MICROSECONDS', false),
+            ],
         ),
         'pgsql' => new Config\PostgresDriverConfig(
             connection: new Config\Postgres\TcpConnectionConfig(
@@ -62,8 +66,12 @@ return [
                 user: env('DB_USERNAME', 'postgres'),
                 password: env('DB_PASSWORD', ''),
             ),
-            schema: 'public',
-            queryCache: true,
+            schema: env('DB_SCHEMA', 'public'),
+            queryCache: env('DB_QUERY_CACHE', true),
+            options: [
+                'logQueryParameters' => env('DB_LOG_QUERY_PARAMETERS', false),
+                'withDatetimeMicroseconds' => env('DB_WITH_DATETIME_MICROSECONDS', false),
+            ],
         ),
         'mysql' => new Config\MySQLDriverConfig(
             connection: new Config\MySQL\TcpConnectionConfig(
@@ -73,7 +81,11 @@ return [
                 user: env('DB_USERNAME', 'root'),
                 password: env('DB_PASSWORD', ''),
             ),
-            queryCache: true,
+            queryCache: env('DB_QUERY_CACHE', true),
+            options: [
+                'logQueryParameters' => env('DB_LOG_QUERY_PARAMETERS', false),
+                'withDatetimeMicroseconds' => env('DB_WITH_DATETIME_MICROSECONDS', false),
+            ],
         ),
         // ...
     ],

--- a/installer/Tests/Module/CycleBridge.php
+++ b/installer/Tests/Module/CycleBridge.php
@@ -46,7 +46,9 @@ final class CycleBridge extends AbstractModule
             'SAFE_MIGRATIONS' => true,
             'CYCLE_SCHEMA_CACHE' => false,
             'CYCLE_SCHEMA_WARMUP' => false,
-            'DB_CONNECTION' => 'sqlite'
+            'DB_CONNECTION' => 'sqlite',
+            'DB_LOG_QUERY_PARAMETERS' => false,
+            'DB_WITH_DATETIME_MICROSECONDS' => false,
         ];
     }
 }


### PR DESCRIPTION
## What was changed

1. The unnecessary bootloaders have been removed from the Kernel.
- Roadrunner bootloaders are added by the generator here:
https://github.com/spiral/app/blob/installer/installer/Module/RoadRunnerBridge/Common/Generator/Bootloaders.php 
If the Roadrunner installation is selected in the installer. 

- YiiErrorHandlerBootloader is also added here:
https://github.com/spiral/app/blob/installer/installer/Module/ErrorHandler/Yii/Generator/Bootloaders.php
If the spiral-packages/yii-error-handler-bridge package is installed.

2. The unnecessary deprecated constants **SYSTEM, LOAD, APP** have been removed.
3. Environment variables have been added to the database config and phpunit.xml config for convenience of use.