### PR TITLE
fix(logging): replace deprecated Logger::ERROR with Monolog\Level::E…

### DIFF
--- a/app/src/Application/Bootloader/LoggingBootloader.php
+++ b/app/src/Application/Bootloader/LoggingBootloader.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Application\Bootloader;
 
-use Monolog\Logger;
+use Monolog\Level;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Http\Middleware\ErrorHandlerMiddleware;
 use Spiral\Monolog\Bootloader\MonologBootloader;
@@ -27,7 +27,7 @@ final class LoggingBootloader extends Bootloader
             channel: MonologConfig::DEFAULT_CHANNEL,
             handler: $monolog->logRotate(
                 filename: directory('runtime').'logs/error.log',
-                level: Logger::ERROR,
+                level: Level::Error,
                 maxFiles: 25,
                 bubble: false,
             ),


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Replaced deprecated `Logger\:\:ERROR` occurrences with `Monolog\\Level\:\:Error`.

## Why?

Ensures future compatibility and removes deprecation warnings.

## Checklist

- Closes #
- Tested
NO Tests needed